### PR TITLE
fix: bump run job memory

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -79,7 +79,7 @@ runs:
         secrets: |
           /secrets/app/secrets.json=secrets:latest
         flags: |
-          --memory=1G
+          --memory=4G
           --task-timeout=1h
           --service-account=cloud-run-sa@${{ inputs.project_id }}.iam.gserviceaccount.com
           --network=${{ inputs.shared_vpc_network }}


### PR DESCRIPTION
Last night the process failed after running out of memory. Here are the tables that it was attempting to update:

['sgid.boundaries.municipalities', 'sgid.boundaries.municipalities_carto', 'sgid.boundaries.municipalities_modifications', 'sgid.cadastre.parcels_carbon', 'sgid.cadastre.parcels_sevier', 'sgid.cadastre.parcels_utah', 'sgid.cadastre.parcels_washington', 'sgid.environment.compliancepst', 'sgid.environment.daqairemissionsinventory', 'sgid.environment.daqairmonitordata', 'sgid.environment.daqpermitcompapproval', 'sgid.environment.daqpermitcomptitlev', 'sgid.environment.deqmap_lust', 'sgid.environment.facilitypst', 'sgid.environment.tankpst', 'sgid.environment.uicauthorization', 'sgid.environment.uicauthorizationaction', 'sgid.environment.uicfacility', 'sgid.environment.uicwell', 'sgid.environment.uicwelloperatingstatus', 'sgid.location.addresspoints', 'sgid.society.lawenforcement', 'sgid.society.lawenforcementboundaries', 'sgid.society.psapboundaries', 'sgid.transportation.roads']

It had added them all to the FGDB and was updating domains when it ran out of memory. I assume that creating the zip file will be another large hit.

If this doesn't work, I can update it to use cloud storage or try to split up the updates into separate FGDBs (perhaps by category).